### PR TITLE
Hookify ƒ(🛠)

### DIFF
--- a/src/assets/css/main.css
+++ b/src/assets/css/main.css
@@ -1,4 +1,5 @@
 @import url('https://fonts.googleapis.com/css?family=Roboto&display=swap');
+
 * {
     font-family: 'Roboto', sans-serif;
     margin: 0;
@@ -11,4 +12,27 @@
 }
 .mt-5 {
     margin-top: 50px;
+}
+
+form {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+}
+
+input[type="submit"] {
+    height: 35px;
+    width: 80%;
+    cursor: pointer;
+    margin: 5px 10px;
+    border-radius: 2px;
+    background-color: #5DADE2;
+    outline: none;
+    color: white;
+    font-size: 18px;
+    box-shadow: 0 1px 3px rgba(0,0,0,0.12), 0 1px 2px rgba(0,0,0,0.24);
+    transition: .2s;
+
 }

--- a/src/components/Form/Login.jsx
+++ b/src/components/Form/Login.jsx
@@ -1,0 +1,39 @@
+import React from 'react'
+import IconInput from '../../components/IconInput'
+import { useForm } from '../../hooks/useForm';
+
+import emailIcon from '../../assets/img/email.svg'
+import passwordIcon from '../../assets/img/locked.svg'
+
+
+export const Login = () => {
+    const { inputs, handleInputChange, handleSubmit } = useForm();
+
+    return (
+        <>
+            <form onSubmit={handleSubmit}>
+                <IconInput
+                    placeholder="Email"
+                    icon={emailIcon}
+                    type="email"
+                    name="email"
+                    value={inputs.email}
+                    change={handleInputChange}
+                />
+                <IconInput
+                    placeholder="Password"
+                    icon={passwordIcon}
+                    type="password"
+                    name="password"
+                    value={inputs.password}
+                    autoComplete="current-password"
+                    required
+                    change={handleInputChange}
+                />
+                <input type="submit" value="Submit!" />
+            </form>
+
+
+        </>
+    )
+}

--- a/src/components/Form/Register.jsx
+++ b/src/components/Form/Register.jsx
@@ -1,0 +1,57 @@
+import React from 'react'
+import IconInput from '../../components/IconInput'
+import { useForm } from '../../hooks/useForm';
+
+import emailIcon from '../../assets/img/email.svg'
+import passwordIcon from '../../assets/img/locked.svg'
+import idIcon from '../../assets/img/identification.svg'
+import phoneIcon from '../../assets/img/telephone.svg'
+
+
+export const Register = () => {
+    const { inputs, handleInputChange, handleSubmit } = useForm();
+    return (
+        <>
+            <form onSubmit={handleSubmit}>
+                <IconInput
+                    placeholder="Full name"
+                    icon={idIcon}
+                    type="text"
+                    name="fullName"
+                    value={inputs.fullName}
+                    change={handleInputChange}
+                    required
+                />
+                <IconInput
+                    placeholder="Email"
+                    icon={emailIcon}
+                    type="email"
+                    name="email"
+                    value={inputs.email}
+                    change={handleInputChange}
+                    required
+                />
+                <IconInput
+                    placeholder="Phone number"
+                    icon={phoneIcon}
+                    type="phone"
+                    name="phone"
+                    value={inputs.phone}
+                    change={handleInputChange}
+                    required
+                />
+                <IconInput
+                    placeholder="Password"
+                    icon={passwordIcon}
+                    type="password"
+                    name="password"
+                    value={inputs.password}
+                    autoComplete="new-password"
+                    required
+                    change={handleInputChange}
+                />
+                <input type="submit" value="Submit!" />
+            </form>
+        </>
+    )
+}

--- a/src/components/IconInput.jsx
+++ b/src/components/IconInput.jsx
@@ -14,14 +14,18 @@ const IconInput = props => {
                 className={`i-i-input ${props.error ? 'i-i-error' : ''}`} 
                 onChange={props.change} 
                 placeholder={props.placeholder} 
+                name={props.name}
+                required={props.required}
             />
         </div>
     )
 }
 
 IconInput.propTypes = {
+    name: PropTypes.string.isRequired,
     error: PropTypes.bool,
     placeholder: PropTypes.string,
+    required: PropTypes.bool,
     icon: PropTypes.string.isRequired,
     type: PropTypes.string.isRequired,
     change: PropTypes.func.isRequired

--- a/src/containers/App.jsx
+++ b/src/containers/App.jsx
@@ -1,99 +1,40 @@
-import React, { useState } from 'react'
+import React from 'react'
 
 import SmallCard from '../components/SmallCard'
 import CardTabs from '../components/CardTabs'
 import BodyCard from '../components/BodyCard'
-import IconInput from '../components/IconInput'
-import ButtonLarge from '../components/buttonLarge'
 
-import emailIcon from '../assets/img/email.svg'
-import passwordIcon from '../assets/img/locked.svg'
-import idIcon from '../assets/img/identification.svg'
-import phoneIcon from '../assets/img/telephone.svg'
+import { useTabs } from '../hooks/useTabs'
 
-const App = props => {
-    // State
-    const [actual, setActual] = useState('Login');
+//Pages
+import { Register } from '../components/Form/Register'
+import { Login } from '../components/Form/Login'
 
-    // State Login
-    const [emailLogin, setEmailLogin] = useState('');
-    const [passwordLogin, setPasswordLogin] = useState('');
+const App = () => {
 
-    // State Register
-    const [emaiRegister, setEmaiRegister] = useState('');
-    const [passwordRegister, setPasswordRegister] = useState('');
-    const [nameRegister, setNameRegiter] = useState('');
-    const [phoneRegister, setPhoneRegister] = useState('');
+    const { actual, changeActual } = useTabs('Login')
+    const pages = [
+        {
+            text: "Login",
+            action: changeActual("Login")
+        },
+        {
+            text: "Register",
+            action: changeActual("Register")
+        }
+    ]
 
-    // Events handlers
-    const changeActual = (item) => {
-        return () => setActual(item);
-    }
     return (
         <>
             <SmallCard className="mt-5">
-                <CardTabs buttons={[
-                        {
-                            text: "Login",
-                            action: changeActual("Login")
-                        }, 
-                        {
-                            text: "Register",
-                            action: changeActual("Register")
-                        }
-                    ]}
-                    actual={actual}
-                />
+                <CardTabs buttons={pages} actual={actual} />
                 <BodyCard>
                     {
-                        (actual === 'Login') ?
-                            <> 
-                                <IconInput 
-                                    placeholder="Email"
-                                    icon={emailIcon}
-                                    type="email"
-                                    change={e => setEmailLogin(e.target.value)}
-                                />
-                                <IconInput 
-                                    placeholder="Password"
-                                    icon={passwordIcon}
-                                    type="password"
-                                    change={e => setPasswordLogin(e.target.value)}
-                                />
-                            </>
-                        :
-                            (actual === 'Register') ?
-                                <>
-                                    <IconInput 
-                                        placeholder="Full name"
-                                        icon={idIcon}
-                                        type="text"
-                                        change={e => setNameRegiter(e.target.value)}
-                                    />
-                                    <IconInput 
-                                        placeholder="Email"
-                                        icon={emailIcon}
-                                        type="email"
-                                        change={e => setEmaiRegister(e.target.value)}
-                                    />
-                                    <IconInput 
-                                        placeholder="Phone number"
-                                        icon={phoneIcon}
-                                        type="phone"
-                                        change={e => setPhoneRegister(e.target.value)}
-                                    />
-                                    <IconInput 
-                                        placeholder="Password"
-                                        icon={passwordIcon}
-                                        type="password"
-                                        change={e => setPasswordRegister(e.target.value)}
-                                    />
-                                </>
-                            :
-                                null
+                        (actual === pages[0].text)
+                            ? <Login />
+                            : <Register />
                     }
                 </BodyCard>
-                <ButtonLarge value="Success!" click={() => {console.log('yep')}} />
             </SmallCard>
         </>
     )

--- a/src/hooks/useForm.js
+++ b/src/hooks/useForm.js
@@ -1,0 +1,24 @@
+import { useState } from 'react'
+
+export const useForm = () => {
+    
+    const [inputs, setInputs] = useState({})
+    const handleSubmit = event => {
+        event.preventDefault()
+        console.table(inputs)
+    }
+    
+    const handleInputChange = event => {
+        event.persist();
+        
+        setInputs(inputs => (
+            { ...inputs, [event.target.name]: event.target.value  }
+        ));
+    }
+
+    return {
+        handleSubmit,
+        handleInputChange,
+        inputs
+    };
+}

--- a/src/hooks/useTabs.js
+++ b/src/hooks/useTabs.js
@@ -1,0 +1,12 @@
+import { useState } from 'react'
+
+export const useTabs = (initialPage) => {
+    const [actual, setActual] = useState(initialPage)
+    const changeActual = item => () => setActual(item)
+
+    return {
+        setActual,
+        changeActual,
+        actual,
+    }
+};


### PR DESCRIPTION
This PR only presents a different way to manage your states without using a Dummy/Smart pattern (at least not 100%).

- Adds `useTabs` and `useForm` hooks.
With `useTabs` we manage the Tabs State of the AuthForm (A.K.A App. AuthForm can be a component)
With `useInput` We make DRY glory. We don't have to repeat the same state logic over and over again. So the code is cleaner, reusable and easier to interpret.

- Now, we could move our Tabs logic into something like `AuthForm` and leave the root component (App) much cleaner than even at the time of making the initia commit of CRA.


Cheers 🎊